### PR TITLE
Check for access to object before signing URL

### DIFF
--- a/main.go
+++ b/main.go
@@ -31,6 +31,15 @@ func main() {
 	})
 	client := s3.New(session)
 
+	_, err := client.HeadObject(&s3.HeadObjectInput{
+		Bucket: &args.Bucket,
+		Key:    &args.Key,
+	})
+	if err != nil {
+		log.Println("Failed to fetch s3://" + args.Bucket + "/" + args.Key + ": signed URL will not work.")
+		log.Fatal(err)
+	}
+
 	req, _ := client.GetObjectRequest(&s3.GetObjectInput{
 		Bucket: &args.Bucket,
 		Key:    &args.Key,


### PR DESCRIPTION
This ensures the bucket and key exist, and the credentials in use have access to them.

Without this check, a signed URL will always be produced, but it's not guaranteed to ever work.